### PR TITLE
Fix azure pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,18 +30,32 @@ steps:
   condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))
 
 - bash: |
-    echo ">>> Compile vscode-plasticscm"
+    echo ">>> Install node modules"
     npm install
+    echo "<<< Installed node modules"
+  displayName: Install Modules
+  env:
+    DISPLAY: ':99.0'
+
+- bash: |
+    echo ">>> Compile vscode-plasticscm"
     npm run compile
-    echo ">>> Compiled vscode-plasticscm"
+    echo "<<< Compiled vscode-plasticscm"
+  displayName: Compile extension
+  env:
+    DISPLAY: ':99.0'
+
+- bash: |
     echo ">>> Run tests"
     npm run test
+    echo "<<< Tests ran"
   displayName: Run Tests
   env:
     DISPLAY: ':99.0'
 
 - bash: |
-    echo ">>> Publish"
+    echo ">>> Publishing extension"
     npm run deploy -p $(VSCODE_MARKETPLACE_TOKEN)
+    echo "<<< Extension published"
   displayName: Publish
   condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/'), eq(variables['Agent.OS'], 'Linux'))

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,6 +31,7 @@ steps:
 
 - bash: |
     echo ">>> Compile vscode-plasticscm"
+    npm install
     npm run compile
     echo ">>> Compiled vscode-plasticscm"
     echo ">>> Run tests"

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,3 +1,3 @@
-export { GetWorkspaceFromPath } from "./getWorkspacefrompath/getWorkspaceFromPath";
+export { GetWorkspaceFromPath } from "./getWorkspaceFromPath/getWorkspaceFromPath";
 export { Status } from "./status/status";
 export { Checkin } from "./checkin/checkin";


### PR DESCRIPTION
Missing `npm install` step.
Tests in Linux were failing because case-sensitive FS with a path with wrong casing.