### PR TITLE
Trigger release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,6 @@ jobs:
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:
-      - name: trigger release
-        if: startsWith(github.ref, 'refs/heads/master') && matrix.os == 'ubuntu-latest' && contains(github.event.head_commit.message, 'trigger_release')
-        run: echo "::set-env name=TRIGGER_RELEASE::yes"
-
       - name: checkout repo
         uses: actions/checkout@v2
 
@@ -92,19 +88,4 @@ jobs:
         uses: actions/upload-artifact@v1
         with:
           name: plastic-scm-${{ steps.gitversion.outputs.semVer }}-${{ runner.os }}.vsix
-          path: ${{ github.workspace }}/plastic-scm-${{ steps.gitversion.outputs.semVer }}.vsix
-
-      - name: publish to marketplace
-        if: success() && env.TRIGGER_RELEASE == 'yes'
-        env:
-          VSCE_PAT: ${{ secrets.VscePat }}
-        run: npm run deploy -p ${{ env.VSCE_PAT }}
-
-      - name: create a release
-        if: success() && env.TRIGGER_RELEASE == 'yes'
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: v${{ steps.gitversion.outputs.semVer }}
-          release_name: v${{ steps.gitversion.outputs.semVer }}
+          path: plastic-scm-${{ steps.gitversion.outputs.semVer }}.vsix

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,72 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  release:
+    name: Release ${{  }}
+    runs-on: ubuntu-latest
+    if: "contains(github.event.head_commit.message, 'trigger_release')"
+    defaults:
+      run:
+        working-directory: ${{ github.workspace }}
+
+    steps:
+      - name: checkout repo
+        uses: actions/checkout@v2
+
+      - name: fetch all history and tags for gitversion
+        run: git fetch --prune --unshallow
+
+      - name: install gitversion
+        uses: gittools/actions/gitversion/setup@v0.9.4
+        with:
+          versionSpec: '5.2.x'
+
+      - name: execute gitversion
+        id: gitversion
+        uses: gittools/actions/gitversion/execute@v0.9.4
+
+      - name: print gitversion
+        run: |
+          echo "Major: ${{ steps.gitversion.outputs.major }}"
+          echo "Minor: ${{ steps.gitversion.outputs.minor }}"
+          echo "Patch: ${{ steps.gitversion.outputs.patch }}"
+          echo "MajorMinorPatch: ${{ steps.gitversion.outputs.majorMinorPatch }}"
+          echo "SemVer: ${{ steps.gitversion.outputs.semVer }}"
+
+      - name: update version in package.json
+        if: success() && matrix.os != 'windows-latest'
+        run: |
+          sed -e '/"version"/s/: ".*"/: "${{ steps.gitversion.outputs.semVer }}"/' package.json | tee package.json.modified
+          mv package.json.modified package.json
+
+      - name: publish to marketplace
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+        run: npm run deploy -p ${{ env.VSCE_PAT }}
+
+      - name: create a release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: v${{ steps.gitversion.outputs.semVer }}
+          release_name: v${{ steps.gitversion.outputs.semVer }}
+          draft: false
+          prerelease: false
+
+      - name: upload Release Asset
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
+          asset_path: ./plastic-scm-${{ steps.gitversion.outputs.semVer }}.vsix
+          asset_name: plastic-scm-${{ steps.gitversion.outputs.semVer }}.vsix
+          asset_content_type: application/zip
+      - name: bump version number

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ jobs:
   release:
     name: Release ${{  }}
     runs-on: ubuntu-latest
-    if: "contains(github.event.head_commit.message, 'trigger_release')"
+    if: "contains(github.event.head_commit.message, 'release:trigger')"
     defaults:
       run:
         working-directory: ${{ github.workspace }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
         id: gitversion
         uses: gittools/actions/gitversion/execute@v0.9.4
 
-      - name: print gitversion
+      - name: print gitversion before release
         run: |
           echo "Major: ${{ steps.gitversion.outputs.major }}"
           echo "Minor: ${{ steps.gitversion.outputs.minor }}"
@@ -38,7 +38,6 @@ jobs:
           echo "SemVer: ${{ steps.gitversion.outputs.semVer }}"
 
       - name: update version in package.json
-        if: success() && matrix.os != 'windows-latest'
         run: |
           sed -e '/"version"/s/: ".*"/: "${{ steps.gitversion.outputs.semVer }}"/' package.json | tee package.json.modified
           mv package.json.modified package.json
@@ -59,7 +58,7 @@ jobs:
           draft: false
           prerelease: false
 
-      - name: upload Release Asset
+      - name: upload release asset
         id: upload-release-asset
         uses: actions/upload-release-asset@v1
         env:
@@ -70,3 +69,29 @@ jobs:
           asset_name: plastic-scm-${{ steps.gitversion.outputs.semVer }}.vsix
           asset_content_type: application/zip
       - name: bump version number
+
+      - name: execute gitversion again
+        id: gitversion
+        uses: gittools/actions/gitversion/execute@v0.9.4
+
+      - name: print gitversion after release
+        run: |
+          echo "Major: ${{ steps.gitversion.outputs.major }}"
+          echo "Minor: ${{ steps.gitversion.outputs.minor }}"
+          echo "Patch: ${{ steps.gitversion.outputs.patch }}"
+          echo "MajorMinorPatch: ${{ steps.gitversion.outputs.majorMinorPatch }}"
+          echo "SemVer: ${{ steps.gitversion.outputs.semVer }}"
+
+      - name: update new version in package.json
+        run: |
+          sed -e '/"version"/s/: ".*"/: "${{ steps.gitversion.outputs.semVer }}"/' package.json | tee package.json.modified
+          mv package.json.modified package.json
+
+      - name: commit and push updated package.json
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: '[Automatic] Bump version name'
+          commit_options: '--no-verify --signoff'
+          file_pattern: package.json
+          commit_user_name: Plastic SCM Releases
+          commit_user_email: support@codicesoftware.com


### PR DESCRIPTION
Separate the release workflow from the build one. Also take advantage of GitVersion to automatically tag and bump version number in the repo.