### PR TITLE
Update lodash version in package-lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2183,10 +2183,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-      "dev": true
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
     },
     "lodash.flattendeep": {
       "version": "4.4.0",


### PR DESCRIPTION
Dependabot detected a security issue with the referenced version of `lodash`: https://github.com/advisories/GHSA-p6mc-m468-83gw

This happened in versions < 4.17.19, and we used 4.17.15. This PR updates `lodash` in `package-lock.json` to 4.17.19.