### PR TITLE
Add refresh button

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,12 @@
         "icon": "$(check)"
       },
       {
+        "command": "plastic-scm.refresh",
+        "category": "Plastic SCM",
+        "title": "Refresh",
+        "icon": "$(refresh)"
+      },
+      {
         "command": "plastic-scm.openFile",
         "category": "Plastic SCM",
         "title": "Open File",
@@ -89,6 +95,11 @@
       "scm/title": [
         {
           "command": "plastic-scm.checkin",
+          "group": "navigation",
+          "when": "scmProvider == plastic-scm"
+        },
+        {
+          "command": "plastic-scm.refresh",
           "group": "navigation",
           "when": "scmProvider == plastic-scm"
         }

--- a/src/commands/checkin.ts
+++ b/src/commands/checkin.ts
@@ -23,7 +23,10 @@ export class CheckinCommand implements Disposable {
   }
 
   private async execute(args: any[]): Promise<any> {
-    const workspace: Workspace | undefined = await this.getWorkspace(args);
+    const workspace: Workspace | undefined = args instanceof Workspace ?
+      args as Workspace :
+      await this.mPlasticScm.promptUserToPickWorkspace();
+
     if (!workspace) {
       return;
     }
@@ -57,30 +60,6 @@ export class CheckinCommand implements Disposable {
         await window.showErrorMessage(`Plastic SCM Checkin failed: ${message}`);
       }
     });
-  }
-
-  private async getWorkspace(args: any[]): Promise<Workspace | undefined> {
-    if (args instanceof Workspace) {
-      return args as Workspace;
-    }
-
-    if (this.mPlasticScm.workspaces.size === 1) {
-      return Array.from(this.mPlasticScm.workspaces.values())[0];
-    }
-
-    const choice = await window.showQuickPick(
-      Array.from(this.mPlasticScm.workspaces.values()).map(wk => ({
-        description: wk.info.path,
-        label: wk.info.name,
-        workspace: wk,
-      })),
-      {
-        canPickMany: false,
-        ignoreFocusOut: true,
-        placeHolder: "Checkin to what workspace?",
-      });
-
-    return choice?.workspace;
   }
 
   private async getComment(workspace: Workspace): Promise<string | undefined> {

--- a/src/commands/refresh.ts
+++ b/src/commands/refresh.ts
@@ -1,0 +1,54 @@
+import { commands, Disposable, window } from "vscode";
+import { PlasticScm } from "../plasticScm";
+import { Workspace } from "../workspace";
+
+export class RefreshCommand implements Disposable {
+  private readonly mPlasticScm: PlasticScm;
+  private readonly mDisposable?: Disposable;
+
+  public constructor(plasticScm: PlasticScm) {
+    this.mPlasticScm = plasticScm;
+    this.mDisposable = commands.registerCommand(
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+      "plastic-scm.refresh", args => this.execute(args));
+  }
+
+  public dispose(): void {
+    if (this.mDisposable) {
+      this.mDisposable.dispose();
+    }
+  }
+
+  private async execute(args: any[]): Promise<any> {
+    const workspace: Workspace | undefined = await this.getWorkspace(args);
+    if (!workspace) {
+      return;
+    }
+
+    await workspace.updateWorkspaceStatus();
+  }
+
+  private async getWorkspace(args: any[]): Promise<Workspace | undefined> {
+    if (args instanceof Workspace) {
+      return args as Workspace;
+    }
+
+    if (this.mPlasticScm.workspaces.size === 1) {
+      return Array.from(this.mPlasticScm.workspaces.values())[0];
+    }
+
+    const choice = await window.showQuickPick(
+      Array.from(this.mPlasticScm.workspaces.values()).map(wk => ({
+        description: wk.info.path,
+        label: wk.info.name,
+        workspace: wk,
+      })),
+      {
+        canPickMany: false,
+        ignoreFocusOut: true,
+        placeHolder: "Which workspace would you like to refresh?",
+      });
+
+    return choice?.workspace;
+  }
+}

--- a/src/commands/refresh.ts
+++ b/src/commands/refresh.ts
@@ -20,35 +20,14 @@ export class RefreshCommand implements Disposable {
   }
 
   private async execute(args: any[]): Promise<any> {
-    const workspace: Workspace | undefined = await this.getWorkspace(args);
+    const workspace: Workspace | undefined = args instanceof Workspace ?
+      args as Workspace :
+      await this.mPlasticScm.promptUserToPickWorkspace();
+
     if (!workspace) {
       return;
     }
 
     await workspace.updateWorkspaceStatus();
-  }
-
-  private async getWorkspace(args: any[]): Promise<Workspace | undefined> {
-    if (args instanceof Workspace) {
-      return args as Workspace;
-    }
-
-    if (this.mPlasticScm.workspaces.size === 1) {
-      return Array.from(this.mPlasticScm.workspaces.values())[0];
-    }
-
-    const choice = await window.showQuickPick(
-      Array.from(this.mPlasticScm.workspaces.values()).map(wk => ({
-        description: wk.info.path,
-        label: wk.info.name,
-        workspace: wk,
-      })),
-      {
-        canPickMany: false,
-        ignoreFocusOut: true,
-        placeHolder: "Which workspace would you like to refresh?",
-      });
-
-    return choice?.workspace;
   }
 }

--- a/src/plasticScm.ts
+++ b/src/plasticScm.ts
@@ -108,4 +108,24 @@ export class PlasticScm implements Disposable {
       disposable.dispose();
     });
   }
+
+  public async promptUserToPickWorkspace(): Promise<Workspace | undefined> {
+    if (this.workspaces.size === 1) {
+      return Array.from(this.workspaces.values())[0];
+    }
+
+    const choice = await VsCodeWindow.showQuickPick(
+      Array.from(this.workspaces.values()).map(wk => ({
+        description: wk.info.path,
+        label: wk.info.name,
+        workspace: wk,
+      })),
+      {
+        canPickMany: false,
+        ignoreFocusOut: true,
+        placeHolder: "Which workspace would you like to refresh?",
+      });
+
+    return choice?.workspace;
+  }
 }

--- a/src/plasticScm.ts
+++ b/src/plasticScm.ts
@@ -13,6 +13,7 @@ import { IConfig } from "./config";
 import { IWorkspaceInfo } from "./models";
 import { OpenFileCommand } from "./commands/openFile";
 import { PlasticScmDecorations } from "./decorations";
+import { RefreshCommand } from "./commands/refresh";
 import { Workspace } from "./workspace";
 import { WorkspaceOperations } from "./workspaceOperations";
 
@@ -85,6 +86,7 @@ export class PlasticScm implements Disposable {
 
     if (this.mWorkspaces.size) {
       this.mDisposables.push(new CheckinCommand(this));
+      this.mDisposables.push(new RefreshCommand(this));
       this.mDisposables.push(new OpenFileCommand(this));
       this.mDisposables.push(new PlasticScmDecorations(this));
     }

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -172,29 +172,7 @@ export class Workspace implements Disposable, QuickDiffProvider {
     }
   }
 
-  @throttle(1000)
-  private async onFileChanged(): Promise<void> {
-    if (!this.mConfig.autorefresh) {
-      return;
-    }
-
-    if (this.mbIsStatusSlow) {
-      // IMPROVEMENT: ask the user if they want to keep calculating status on this workspace automatically.
-    }
-
-    if (this.mOperations.isRunning(WorkspaceOperation.Status)) {
-      return;
-    }
-
-    await this.mOperations.run(WorkspaceOperation.Status, async () => {
-      while (this.mShell.isBusy) {
-        await new Promise(resolve => setTimeout(resolve, 100));
-      }
-      await this.updateWorkspaceStatus();
-    });
-  }
-
-  private async updateWorkspaceStatus(): Promise<void> {
+  public async updateWorkspaceStatus(): Promise<void> {
     // Improvement: measure status time and update the 'this.mbIsStatusSlow' flag.
     // ! Status XML output does not print performance warnings!
     const pendingChanges: IPendingChanges =
@@ -247,6 +225,28 @@ export class Workspace implements Disposable, QuickDiffProvider {
     }];
 
     this.onDidChangeStatus.fire();
+  }
+
+  @throttle(1000)
+  private async onFileChanged(): Promise<void> {
+    if (!this.mConfig.autorefresh) {
+      return;
+    }
+
+    if (this.mbIsStatusSlow) {
+      // IMPROVEMENT: ask the user if they want to keep calculating status on this workspace automatically.
+    }
+
+    if (this.mOperations.isRunning(WorkspaceOperation.Status)) {
+      return;
+    }
+
+    await this.mOperations.run(WorkspaceOperation.Status, async () => {
+      while (this.mShell.isBusy) {
+        await new Promise(resolve => setTimeout(resolve, 100));
+      }
+      await this.updateWorkspaceStatus();
+    });
   }
 
   private getCheckinPlaceholder(wkConfig: IWorkspaceConfig) {


### PR DESCRIPTION
This PR fixes #42 by adding a refresh button that calls `workspace.updateWorkspaceStatus()` (after making it a public method).

**Note:** this PR is based off #310, so it includes those commits, please review that one before this one. The contributions of this PR are in commits `760ca1a` and later.