### PR TITLE
Dispose the global shell when it should

### DIFF
--- a/src/plasticScm.ts
+++ b/src/plasticScm.ts
@@ -78,11 +78,11 @@ export class PlasticScm implements Disposable {
         this.mChannel.appendLine(
           `Unable to find workspace in ${workingDir}: ${error?.message}`);
         await VsCodeWindow.showErrorMessage(error?.message);
-      } finally {
-        await globalShell.stop();
-        globalShell.dispose();
       }
     }
+
+    await globalShell.stop();
+    globalShell.dispose();
 
     if (this.mWorkspaces.size) {
       this.mDisposables.push(new CheckinCommand(this));


### PR DESCRIPTION
The extension failed to acknowledge multiple folders when they were saved in different Plastic SCM workspaces. This was caused by a mistake in the disposal of the `cm` shell used in the initialization process.