### PR TITLE
Fix gitversion action version in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,7 +95,7 @@ jobs:
 
       - name: execute gitversion again
         id: gitversion-after
-        uses: gittools/actions/gitversion/execute@v0.9.4
+        uses: gittools/actions/gitversion/execute@v0.9.7
 
       - name: print gitversion after release
         run: |

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Plastic SCM integration",
   "publisher": "plastic-scm",
   "license": "MIT",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "icon": "images/logo.png",
   "homepage": "https://github.com/PlasticSCM/vscode-plasticscm/blob/master/README.md",
   "bugs": {


### PR DESCRIPTION
Ensure both `gitversion` steps in the Release workflow use the same version. During last release, the `gitversion-after` step failed whereas `gitversion-before` didn't. This might be the reason why.

Additionally, this PR bumps up the version number in package.json
to get ready for version 0.1.2.