### PR TITLE
Bump package.json version

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Plastic SCM integration",
   "publisher": "plastic-scm",
   "license": "MIT",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "icon": "images/logo.png",
   "homepage": "https://github.com/PlasticSCM/vscode-plasticscm/blob/master/README.md",
   "bugs": {


### PR DESCRIPTION
The release process failed in https://github.com/PlasticSCM/vscode-plasticscm/actions/runs/3282869918/jobs/5406852368 and it couldn't prepare a PR with the updated version number in `package.json` after release. This PR does that manually.