### PR TITLE
Fix text file diff for partial workspaces

### DIFF
--- a/src/cm/commands/getFile/fileInfoParser.ts
+++ b/src/cm/commands/getFile/fileInfoParser.ts
@@ -1,0 +1,100 @@
+import * as os from "os";
+import * as xml2js from "xml2js";
+import { firstCharLowerCase, parseBooleans, parseNumbers } from "xml2js/lib/processors";
+import { ChangeType } from "../../../models";
+import { ICmParser } from "../../shell";
+import { IFileInfo } from "../../../models/fileInfo";
+import { Uri } from "vscode";
+
+export class FileInfoParser implements ICmParser<IFileInfo> {
+  private readonly mOutputBuffer: string[] = [];
+  private readonly mErrorBuffer: string[] = [];
+  private mParseError?: Error;
+
+  public readLineOut(line: string): void {
+    this.mOutputBuffer.push(line);
+  }
+
+  public readLineErr(line: string): void {
+    this.mErrorBuffer.push(line);
+  }
+
+  public async parse(): Promise<IFileInfo | undefined> {
+    const options: xml2js.OptionsV2 = {
+      explicitArray: false,
+      explicitRoot: false,
+      tagNameProcessors: [firstCharLowerCase],
+      trim: true,
+      valueProcessors: [ parseNumbers, parseBooleans ],
+    };
+
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+      return this.parseXml(await xml2js.parseStringPromise(
+        this.mOutputBuffer.join(""), options));
+    } catch (error) {
+      this.mParseError = error as Error;
+      return undefined;
+    }
+  }
+
+  public getError(): Error | undefined {
+    if (this.mParseError) {
+      return this.mParseError;
+    }
+
+    return this.mErrorBuffer.length !== 0
+      ? new Error(this.mErrorBuffer.join(os.EOL))
+      : undefined;
+  }
+
+  public getOutputLines(): string[] {
+    return this.mOutputBuffer.concat(this.mErrorBuffer);
+  }
+
+  private parseXml(output: IFileInfoOutput): IFileInfo {
+    /* eslint-disable sort-keys */
+    return {
+      clientPath: Uri.file(output.fileInfo.clientPath),
+      relativePath: output.fileInfo.relativePath,
+      serverPath: output.fileInfo.serverPath,
+      size: output.fileInfo.size,
+      hash: output.fileInfo.hash,
+      owner: output.fileInfo.owner,
+      revisionChangeset: output.fileInfo.revisionChangeset,
+      status: STATUS_TYPES[output.fileInfo.status] ?? ChangeType.Private,
+      isUnderXlink: output.fileInfo.isUnderXlink,
+      isXlink: output.fileInfo.isXlink,
+      repSpec: output.fileInfo.repSpec,
+    };
+    /* eslint-enable sort-keys */
+  }
+}
+
+/* eslint-disable sort-keys */
+const STATUS_TYPES: { [key: string]: ChangeType } = {
+  "added": ChangeType.Added,
+  "changed": ChangeType.Changed,
+  "controlled": ChangeType.Controlled,
+  "checked-out": ChangeType.Checkedout,
+  "deleted": ChangeType.Deleted,
+  "private": ChangeType.Private,
+  "moved": ChangeType.Moved,
+};
+/* eslint-enable sort-keys */
+
+interface IFileInfoOutput {
+  fileInfo: {
+    clientPath: string;
+    relativePath: string;
+    serverPath: string;
+    size: number;
+    hash: string;
+    owner: string;
+    revisionChangeset: number;
+    status: string;
+    isUnderXlink: boolean;
+    isXlink: boolean;
+    repSpec: string;
+  };
+}

--- a/src/cm/commands/getFile/getFile.ts
+++ b/src/cm/commands/getFile/getFile.ts
@@ -7,16 +7,6 @@ import { IFileInfo } from "../../../models/fileInfo";
 import { Uri } from "vscode";
 
 export class GetFile {
-  public static cachedFileLocation(
-      rootDir: string,
-      filePath: Uri,
-      changeset: number
-  ): Uri {
-    const cacheDir = join(rootDir, ".plastic", "fileCache");
-    const outputFile = join(cacheDir, changeset.toString(), relative(rootDir, filePath.fsPath));
-    return Uri.file(outputFile);
-  }
-
   public static async run(
       rootDir: string,
       filePath: Uri,

--- a/src/models/fileInfo.ts
+++ b/src/models/fileInfo.ts
@@ -1,0 +1,16 @@
+import { ChangeType } from "./changeInfo";
+import { Uri } from "vscode";
+
+export interface IFileInfo {
+  clientPath: Uri;
+  relativePath: string;
+  serverPath: string;
+  size: number;
+  hash: string;
+  owner: string;
+  revisionChangeset: number;
+  status: ChangeType;
+  isUnderXlink: boolean;
+  isXlink: boolean;
+  repSpec: string;
+}

--- a/src/plasticScmResource.ts
+++ b/src/plasticScmResource.ts
@@ -52,11 +52,12 @@ export class PlasticScmResource implements SourceControlResourceState {
   };
 
   private mChangeInfo: IChangeInfo;
-  private mWorkspace: Workspace;
+  private mCachedOriginalFile: Uri | null;
 
-  public constructor(changeInfo: IChangeInfo, workspace: Workspace) {
+  public constructor(changeInfo: IChangeInfo, cachedOriginalFile?: Uri) {
     this.mChangeInfo = changeInfo;
-    this.mWorkspace = workspace;
+
+    this.mCachedOriginalFile = cachedOriginalFile || null;
   }
 
   @memoize
@@ -154,17 +155,11 @@ export class PlasticScmResource implements SourceControlResourceState {
       ChangeType.Deleted;
 
     if (
-      this.mWorkspace.currentChangeset >= 0 &&
+      this.mCachedOriginalFile !== null &&
       (this.mChangeInfo.type & unallowedFlag) === 0
     ) {
-      const originalFile = GetFile.cachedFileLocation(
-        this.mWorkspace.info.path,
-        this.resourceUri,
-        this.mWorkspace.currentChangeset
-      );
-
       return {
-        arguments: [ originalFile, this.resourceUri, `${path.basename(this.resourceUri.fsPath)} (Diff)` ],
+        arguments: [ this.mCachedOriginalFile, this.resourceUri, `${path.basename(this.resourceUri.fsPath)} (Diff)` ],
         command: "vscode.diff",
         title: "Open",
       };

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -204,6 +204,8 @@ export class Workspace implements Disposable, QuickDiffProvider {
         continue;
       }
 
+      let cachedFileLocation: Uri | undefined;
+
       // prefetch original files for showing diff
       const unallowedFlag = ChangeType.Added | ChangeType.Private | ChangeType.Deleted | ChangeType.Moved;
       if (
@@ -218,13 +220,18 @@ export class Workspace implements Disposable, QuickDiffProvider {
 
         if (cachedFileType === false) {
           try {
-            await CmGetFileCommand.run(this.mWkInfo.path, changeInfo.path, pendingChanges.changeset, this.mShell);
+            cachedFileLocation = await CmGetFileCommand.run(
+              this.mWkInfo.path,
+              changeInfo.path,
+              pendingChanges.changeset,
+              this.mShell
+            );
           } catch (e: any) {
             this.mChannel.appendLine(`Error trying to get file ${changeInfo.path.toString()}: ${(e as Error).message}`);
           }
         }
       }
-      sourceControlResources.push(new PlasticScmResource(changeInfo, this));
+      sourceControlResources.push(new PlasticScmResource(changeInfo, cachedFileLocation));
     }
 
     if (this.mConfig.consolidateUnrealOneFilePerActorChanges) {


### PR DESCRIPTION
This PR fixes #444 by adding a fallback method to use `cm fileinfo` if `cm status` returns `-1` for the changeset (which happens for partial workspaces when targeting a branch).