### PR TITLE
Configure GitVersion action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - name: install gitversion
         uses: gittools/actions/gitversion/setup@v3.0.4
         with:
-          versionSpec: '6.x'
+          versionSpec: '6.0.x'
 
       - name: execute gitversion
         id: gitversion

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,13 +26,13 @@ jobs:
         run: git fetch --prune --unshallow
 
       - name: install gitversion
-        uses: gittools/actions/gitversion/setup@v3.0.0
+        uses: gittools/actions/gitversion/setup@v3.0.4
         with:
           versionSpec: '6.x'
 
       - name: execute gitversion
         id: gitversion
-        uses: gittools/actions/gitversion/execute@v3.0.0
+        uses: gittools/actions/gitversion/execute@v3.0.4
 
       - name: print gitversion
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
       - name: install gitversion
         uses: gittools/actions/gitversion/setup@v3.0.4
         with:
-          versionSpec: '6.x'
+          versionSpec: '6.0.x'
 
       - name: execute gitversion
         id: gitversion-before

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,13 +29,13 @@ jobs:
         run: git fetch --prune --unshallow
 
       - name: install gitversion
-        uses: gittools/actions/gitversion/setup@v3.0.0
+        uses: gittools/actions/gitversion/setup@v3.0.4
         with:
           versionSpec: '6.x'
 
       - name: execute gitversion
         id: gitversion-before
-        uses: gittools/actions/gitversion/execute@v3.0.0
+        uses: gittools/actions/gitversion/execute@v3.0.4
 
       - name: print gitversion before release
         run: |
@@ -95,7 +95,7 @@ jobs:
 
       - name: execute gitversion again
         id: gitversion-after
-        uses: gittools/actions/gitversion/execute@v3.0.0
+        uses: gittools/actions/gitversion/execute@v3.0.4
 
       - name: print gitversion after release
         run: |


### PR DESCRIPTION
GitVersion just released version 6.1. That's not supported by v3.x of the GitHub action. So, we have to request version 6.0.x of GitVersion until action version 4.x is released.